### PR TITLE
Remove redundant config struct

### DIFF
--- a/cmd/node/config.json
+++ b/cmd/node/config.json
@@ -1,15 +1,5 @@
 {
   "peers": [
-    {
-      "ID": "12D3KooWNdPPTfYEisARUD2wjXxfPAVMGs5UQKQ5erWVGSYBzYv4",
-      "Addrs": [
-        "/ip4/127.0.0.1/tcp/53172",
-        "/ip4/10.0.0.4/tcp/53172",
-        "/ip4/10.26.249.167/tcp/53172",
-        "/ip6/::1/tcp/53173",
-        "/ip6/fdd7:9d91:d3a9:0:1cbd:587b:f285:ca70/tcp/53173",
-        "/ip6/fdd7:9d91:d3a9:0:1d37:cd30:aaa4:291/tcp/53173"
-      ]
-    }
+    {"Addrs":["/ip4/127.0.0.1/tcp/54586","/ip4/192.168.43.9/tcp/54586","/ip6/::1/tcp/54587"],"ID":"12D3KooWPRQQDJr7ptNfuZWrL6b2EpBAr92RxoYG3hXRBLagPkYq"}
   ]
 }

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -2,19 +2,19 @@ package main
 
 import (
 	"encoding/json"
-	pnet_node "github.com/amirylm/go-libp2p-pnet-node/lib"
-	"github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
-	"github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-core/pnet"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+
+	pnet_node "github.com/amirylm/go-libp2p-pnet-node/lib"
+	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/pnet"
 )
 
 func startNode(psk pnet.PSK, priv crypto.PrivKey, peers []peer.AddrInfo) (*pnet_node.PrivateNetNode, error) {
@@ -44,7 +44,7 @@ func main() {
 	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, 1)
 	psk := []byte("XVlBzgbaiCMRAjWwhTHctcuAxhxKQFDa")
 
-	var cfg Config
+	var cfg pnet_node.Options
 	p, err := filepath.Abs("./cmd/node/config.json")
 	check(err)
 	b, err := ioutil.ReadFile(p)
@@ -53,37 +53,25 @@ func main() {
 	}
 	log.Printf("num of peers: %d", len(cfg.Peers))
 
-	rel, err := startNode(psk, priv, cfg.Peers)
+	node, err := startNode(psk, priv, cfg.Peers)
 	check(err)
 
 	log.Println("node is ready:")
-	printHost(rel.Node)
+	log.Println(pnet_node.SerializePeer(node.Node))
 
 	// wait for a SIGINT or SIGTERM signal
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	<-ch
 
-	errs := rel.Close()
+	errs := node.Close()
 	for _, err := range errs {
 		check(err)
 	}
 }
 
-type Config struct {
-	Peers []peer.AddrInfo `json:"peers"`
-}
-
 func check(err error) {
 	if err != nil {
 		log.Panic(err)
-	}
-}
-
-func printHost(h host.Host) {
-	id := h.ID().Pretty()
-	log.Printf("%s, listening on:", id)
-	for _, addr := range h.Addrs() {
-		log.Printf("\t- %s", addr.String())
 	}
 }

--- a/cmd/relayer/main.go
+++ b/cmd/relayer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/libp2p/go-libp2p-core/host"
 	"io/ioutil"
 	"log"
 	"os"
@@ -12,7 +11,6 @@ import (
 
 	pnet_node "github.com/amirylm/go-libp2p-pnet-node/lib"
 	pnet_relay "github.com/amirylm/go-libp2p-pnet-node/lib/circuit-relay"
-
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -41,7 +39,7 @@ func main() {
 	priv, _, _ := crypto.GenerateKeyPair(crypto.Ed25519, 1)
 	psk := []byte("XVlBzgbaiCMRAjWwhTHctcuAxhxKQFDa")
 
-	var cfg Config
+	var cfg pnet_node.Options
 	p, err := filepath.Abs("./cmd/relayer/config.json")
 	check(err)
 	b, err := ioutil.ReadFile(p)
@@ -54,7 +52,7 @@ func main() {
 	check(err)
 
 	log.Println("circuit relay node is ready:")
-	printHost(rel.Node)
+	log.Println(pnet_node.SerializePeer(rel.Node))
 
 	// wait for a SIGINT or SIGTERM signal
 	ch := make(chan os.Signal, 1)
@@ -71,16 +69,4 @@ func check(err error) {
 	if err != nil {
 		log.Panic(err)
 	}
-}
-
-func printHost(h host.Host) {
-	id := h.ID().Pretty()
-	log.Printf("%s, listening on:", id)
-	for _, addr := range h.Addrs() {
-		log.Printf("\t- %s", addr.String())
-	}
-}
-
-type Config struct {
-	Peers []peer.AddrInfo `json:"peers"`
 }

--- a/lib/opts.go
+++ b/lib/opts.go
@@ -2,15 +2,16 @@ package lib
 
 import (
 	"context"
+
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/pnet"
 	secio "github.com/libp2p/go-libp2p-secio"
 	libp2ptls "github.com/libp2p/go-libp2p-tls"
 	"github.com/multiformats/go-multiaddr"
-	"math/rand"
 )
 
 // ConfigureLibp2pOpts is the custom config hook interface
@@ -18,23 +19,25 @@ type ConfigureLibp2pOpts = func([]libp2p.Option) ([]libp2p.Option, error)
 
 // Options holds the needed configuration for creating a private node instance
 type Options struct {
-	Ctx      context.Context
+	Ctx context.Context
 	// PrivKey of the current node
-	PrivKey  crypto.PrivKey
+	PrivKey crypto.PrivKey
 	// Secret is the private network secret ([32]byte)
-	Secret   pnet.PSK
+	Secret pnet.PSK
 	// Addrs are Multiaddrs for the current node, will fallback to libp2p defaults
-	Addrs    []multiaddr.Multiaddr
+	Addrs []multiaddr.Multiaddr
 	// Logger to use (see github.com/ipfs/go-log/v2)
 	// will fallback to defaultLogger()
-	Logger	 logging.EventLogger
+	Logger logging.EventLogger
 	// DS is the data store used by DHT
-	DS       datastore.Batching
+	DS datastore.Batching
 	// UseLibp2pOpts is a hook for configuring custom libp2p options
 	UseLibp2pOpts ConfigureLibp2pOpts
 	// Discovery contains configuration of discovery services
 	// unless Discovery is nil, local mdns will be added by default
 	Discovery *DiscoveryOptions
+	// Peers are nodes that we want to connect on bootstrap
+	Peers []peer.AddrInfo
 }
 
 // NewOptions creates the minimum needed Options
@@ -95,24 +98,4 @@ func (opts *Options) defaults() error {
 		}
 	}
 	return nil
-}
-
-// PNetSecret creates a new random secret
-func PNetSecret() pnet.PSK {
-	return randBytes(32)
-}
-
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-// randBytes creates a random string in the given length
-func randBytes(n int) []byte {
-	b := make([]byte, n)
-	letters := len(letterBytes)
-	for i := range b {
-		b[i] = letterBytes[rand.Intn(letters)]
-	}
-	return b[:]
-}
-
-func defaultLogger() logging.EventLogger {
-	return logging.Logger("libp2p-pnet-node")
 }

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1,0 +1,45 @@
+package lib
+
+import (
+	"encoding/json"
+	"math/rand"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/pnet"
+)
+
+// PNetSecret creates a new random secret
+func PNetSecret() pnet.PSK {
+	return randBytes(32)
+}
+
+func SerializeAddrInfo(info peer.AddrInfo) string {
+	b, err := json.Marshal(info)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func SerializePeer(h host.Host) string {
+	pi := peer.AddrInfo{h.ID(), h.Addrs()}
+	return SerializeAddrInfo(pi)
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// randBytes creates a random string in the given length
+func randBytes(n int) []byte {
+	b := make([]byte, n)
+	letters := len(letterBytes)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(letters)]
+	}
+	return b[:]
+}
+
+func defaultLogger() logging.EventLogger {
+	return logging.Logger("libp2p-pnet-node")
+}


### PR DESCRIPTION
Avoid using a custom config struct within ./cdm/*
Instead, node options is being used.